### PR TITLE
buddy system case added

### DIFF
--- a/cau15841-pintos2-qemu/lib/kernel/bitmap.c
+++ b/cau15841-pintos2-qemu/lib/kernel/bitmap.c
@@ -373,6 +373,14 @@ bitmap_scan (const struct bitmap *b, size_t start, size_t cnt, bool value)
         if ( returnFlag ) return n;
       }
       break;
+    case 3:
+	if (cnt <= b->bit_cnt) {
+        size_t last = b->bit_cnt - cnt;
+        size_t i;
+        for (i = start; i <= last; i=i+cnt)
+          if (!bitmap_contains (b, i, cnt, !value))
+            return i; 
+      }
     default: break;
   }
 

--- a/cau15841-pintos2-qemu/threads/palloc.c
+++ b/cau15841-pintos2-qemu/threads/palloc.c
@@ -65,6 +65,26 @@ palloc_init (size_t user_page_limit)
              user_pages, "user pool");
 }
 
+
+/* this fuction will return size of pages for buddy system*/
+size_t count_page(size_t page_cnt){
+	int temp;
+	int count; // count k (2^k-1 < page_cnt <= 2^k)
+	count = 1;
+	temp=page_cnt;
+	while(1){
+      		if(count<page_cnt&&page_cnt<=count*2){
+			page_cnt=count*2;
+			break;
+		}
+		count=count*2;
+	}
+	printf("original page that wanted : %d\nmodified page : %d\n",temp,page_cnt);
+
+	return page_cnt;
+}
+
+
 /* Obtains and returns a group of PAGE_CNT contiguous free pages.
    If PAL_USER is set, the pages are obtained from the user pool,
    otherwise from the kernel pool.  If PAL_ZERO is set in FLAGS,
@@ -80,6 +100,12 @@ palloc_get_multiple (enum palloc_flags flags, size_t page_cnt)
 
   if (page_cnt == 0)
     return NULL;
+
+  if (pallocator==3){ // page_cnt will be modified when allocate type is buddy system
+	if(page_cnt!=1) // if page_cnt is 1, no need to modify the size of page
+		page_cnt=count_page(page_cnt);
+  }
+  
 
   lock_acquire (&pool->lock);
   page_idx = bitmap_scan_and_flip (pool->used_map, 0, page_cnt, false);
@@ -128,6 +154,12 @@ palloc_free_multiple (void *pages, size_t page_cnt)
   ASSERT (pg_ofs (pages) == 0);
   if (pages == NULL || page_cnt == 0)
     return;
+
+  if(pallocator==3){ // page_cnt will be modified if allocate type is buddy system
+	if (page_cnt!=1){ // if page_cnt is 1, no need to modify the size of page
+		page_cnt=count_page(page_cnt);
+	}
+  }
 
   if (page_from_pool (&kernel_pool, pages))
     pool = &kernel_pool;


### PR DESCRIPTION
일단 확실히 완성된건 2^k-1 < 요청된 페이지 수 <= 2^k일때 할당하는 페이지 수를 2^k로 바꿔주는것
free할때도 마찬가지로 이 작업이 필요함. 페이지 수를 조작하는 건 palloc.c에 구현되어있음
(count_page 함수 추가, palloc_get_multiple과 palloc_free_multiple에 count_page 함수 사용됨)

bitmap.c에서는 요청된 페이지 크기에 따라 할당할 장소를 정하는데, First fit에서 약간 변형된 방식.
First fit은 시작지점부터 끝까지 하나씩 건너가며 모든 경우에 대해서 보지만, 이 경우엔 요청된 페이지 크기 수만큼 건너가며 메모리 할당 가능여부를 확인한다. 요청된 페이지의 수가 32라면 0, 32, 64, 96 ... 이렇게 건너가며 비어있는 공간을 찾는 방식.